### PR TITLE
Add build and deploy workflow

### DIFF
--- a/.github/workflows/build-deploy.yml
+++ b/.github/workflows/build-deploy.yml
@@ -1,0 +1,65 @@
+name: Build and deploy
+on:
+  workflow_dispatch:
+  workflow_run:
+    workflows: ["Verify"]
+    branches:
+      - main
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Build
+        run: |
+          echo "BUILD_DATE=$(date +%Y%m%d%H%M)" >> $GITHUB_ENV
+          docker build \
+            --label build.git.sha=${{ github.sha }} \
+            --label build.git.branch=${{ github.head_ref }} \
+            --label build.date=${{ env.BUILD_DATE }} \
+            --build-arg APP_BUILD_DATE=${{ env.BUILD_DATE }} \
+            --build-arg APP_BUILD_TAG=${{ github.head_ref }} \
+            --build-arg APP_GIT_COMMIT=${{ github.sha }} \
+            -t app .
+
+      - name: Push to ECR
+        id: ecr
+        uses: jwalton/gh-ecr-push@v1
+        with:
+          access-key-id: ${{ secrets.ECR_AWS_ACCESS_KEY_ID }}
+          secret-access-key: ${{ secrets.ECR_AWS_SECRET_ACCESS_KEY }}
+          region: eu-west-2
+          local-image: app
+          image: ${{ secrets.ECR_NAME }}:${{ github.sha }}, ${{ secrets.ECR_NAME }}:staging.latest
+
+  deploy-staging:
+    runs-on: ubuntu-latest
+    needs: build
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
+
+    env:
+      KUBE_CLUSTER: ${{ secrets.KUBE_CLUSTER }}
+      KUBE_NAMESPACE: elsa-relevant-search-staging
+
+    steps:
+      - name: Authenticate to the cluster
+        env:
+          KUBE_CERT: ${{ secrets.KUBE_CERT }}
+          KUBE_TOKEN: ${{ secrets.KUBE_TOKEN }}
+        run: |
+          echo "${KUBE_CERT}" > ca.crt
+          kubectl config set-cluster ${KUBE_CLUSTER} --certificate-authority=./ca.crt --server=https://api.${KUBE_CLUSTER}
+          kubectl config set-credentials deploy-user --token=${KUBE_TOKEN}
+          kubectl config set-context ${KUBE_CLUSTER} --cluster=${KUBE_CLUSTER} --user=deploy-user --namespace=${KUBE_NAMESPACE}
+          kubectl config use-context ${KUBE_CLUSTER}
+
+      - name: Rollout restart deployment
+        run: |
+          kubectl set image -n ${KUBE_NAMESPACE} \
+          deployment/elsa-relevant-search-deployment-staging \
+          webapp="${{ secrets.ECR_URL }}:${{ github.sha }}"


### PR DESCRIPTION
This will take care of building the docker image, push to the ECR repo,
and trigger a rollout restart deploy.

**NOTE:** testing this workflow for now so some steps are left out until
this is working smooth.