### PR TITLE
Add the google custom search component

### DIFF
--- a/.github/workflows/test-build-deploy.yml
+++ b/.github/workflows/test-build-deploy.yml
@@ -1,9 +1,13 @@
-name: Test, build and deploy
+name: CI and CD
 on:
   pull_request:
   push:
     branches:
       - main
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   test:

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -1,2 +1,3 @@
 @import "local/govuk";
+@import "local/cse";
 @import "local/custom";

--- a/app/assets/stylesheets/local/cse.scss
+++ b/app/assets/stylesheets/local/cse.scss
@@ -1,0 +1,83 @@
+// Google custom search
+//
+.gsc-control-cse {
+  padding-left: 0 !important;
+}
+
+.gsc-resultsbox-visible {
+  margin-top: 20px;
+}
+
+.gs-per-result-labels {
+  margin-top: 5px;
+  color: $govuk-secondary-text-colour;
+
+  a.gs-label {
+    color: $govuk-secondary-text-colour !important;
+  }
+}
+
+.gsc-tabHeader {
+  margin-left: 3px;
+  margin-right: 3px;
+}
+
+.gs-visibleUrl-breadcrumb {
+  visibility: hidden;
+}
+
+a.gs-title {
+  @include govuk-typography-common;
+  @include govuk-link-decoration;
+
+  font-size: 19px !important;
+
+  b {
+    font-size: 19px !important;
+  }
+
+  &:focus {
+    @include govuk-focused-text;
+
+    b {
+      color: $govuk-focus-text-colour;
+      background-color: $govuk-focus-colour;
+    }
+  }
+
+  &:hover, &:focus {
+    @include govuk-link-hover-decoration;
+
+    text-decoration: underline;
+    text-decoration-thickness: 2px;
+  }
+}
+
+.gsc-table-cell-snippet-close {
+  @extend .govuk-body;
+  margin-bottom: 10px;
+  font-size: 16px !important;
+}
+
+.gsc-cursor-box {
+  padding-top: 20px;
+  padding-bottom: 15px;
+}
+
+.gsc-cursor-page {
+  border: 1px solid $govuk-border-colour;
+  padding: 8px;
+  margin-right: 12px;
+}
+
+.gcsc-more-maybe-branding-root a {
+  font-size: 16px !important;
+}
+
+.gcsc-find-more-on-google-branding {
+  display: none !important;
+}
+
+.gsc-cursor {
+  font-size: 16px !important;
+}

--- a/app/assets/stylesheets/local/custom.scss
+++ b/app/assets/stylesheets/local/custom.scss
@@ -1,5 +1,18 @@
 // App-specific custom styles and overrides
 //
-.no-italic {
-  font-style: normal;
+.app--js-enabled-show {
+  display: none;
+}
+
+.js-enabled {
+  .app--js-enabled-show {
+    display: unset;
+  }
+}
+
+ul.app--query-examples {
+  li {
+    display: inline;
+    margin-right: govuk-spacing(2);
+  }
 }

--- a/app/views/home/index.html.erb
+++ b/app/views/home/index.html.erb
@@ -6,5 +6,118 @@
       <%= service_name %>
     </h1>
 
+    <div class="app--js-enabled-show">
+      <p class="govuk-body-l"><%=t '.lead' %></p>
+      <p class="govuk-body"><%=t '.intro' %></p>
+    </div>
+
+    <noscript>
+      <div class="govuk-warning-text">
+        <span class="govuk-warning-text__icon" aria-hidden="true">!</span>
+        <strong class="govuk-warning-text__text">
+          <span class="govuk-warning-text__assistive">Warning</span>
+          <%=t '.no_javascript.warning' %>
+        </strong>
+      </div>
+      <%=t '.no_javascript.other_links_html' %>
+    </noscript>
+
+    <script async src="https://cse.google.com/cse.js?cx=35494a494c787b70b"></script>
+    <div class="gcse-search" data-personalizedAds="false"></div>
+
+    <div class="app--js-enabled-show">
+      <h2 class="govuk-heading-m govuk-!-margin-top-5">
+        <%=t '.quick_search_heading' %>
+      </h2>
+
+      <p class="govuk-body govuk-!-font-weight-bold govuk-!-margin-bottom-1">Benefits</p>
+
+      <ul class="govuk-list app--query-examples">
+        <li>
+          <a href="#gsc.q=housing%20benefit">housing benefit</a>
+        </li>
+        <li>
+          <a href="#gsc.q=child%20benefit">child benefit</a>
+        </li>
+        <li>
+          <a href="#gsc.q=benefit%20cap">benefit cap</a>
+        </li>
+        <li>
+          <a href="#gsc.q=challenging%20benefit%20decisions">challenging benefit decisions</a>
+        </li>
+        <li>
+          <a href="#gsc.q=appealing%20benefit%20sanctions">appealing benefit sanctions</a>
+        </li>
+      </ul>
+
+      <p class="govuk-body govuk-!-font-weight-bold govuk-!-margin-bottom-1">Debt</p>
+
+      <ul class="govuk-list app--query-examples">
+        <li>
+          <a href="#gsc.q=debt%20advice">debt advice</a>
+        </li>
+        <li>
+          <a href="#gsc.q=debt%20relief">debt relief</a>
+        </li>
+        <li>
+          <a href="#gsc.q=bankruptcy">bankruptcy</a>
+        </li>
+        <li>
+          <a href="#gsc.q=loan%20sharks">loan sharks</a>
+        </li>
+        <li>
+          <a href="#gsc.q=court%20letters%20for%20debt ">court letters for debt</a>
+        </li>
+        <li>
+          <a href="#gsc.q=demands%20for%20debt%20repayments">demands for debt repayments</a>
+        </li>
+      </ul>
+
+      <p class="govuk-body govuk-!-font-weight-bold govuk-!-margin-bottom-1">Employment</p>
+
+      <ul class="govuk-list app--query-examples">
+        <li>
+          <a href="#gsc.q=pension%20disputes">pension disputes</a>
+        </li>
+        <li>
+          <a href="#gsc.q=unfair%20dismissal">unfair dismissal</a>
+        </li>
+        <li>
+          <a href="#gsc.q=discrimination%20at%20work">discrimination at work</a>
+        </li>
+        <li>
+          <a href="#gsc.q=harassment">harassment</a>
+        </li>
+        <li>
+          <a href="#gsc.q=working%20conditions">working conditions</a>
+        </li>
+        <li>
+          <a href="#gsc.q=reasonable%20adjustments%20for%20disabilities">reasonable adjustments for disabilities</a>
+        </li>
+      </ul>
+
+      <p class="govuk-body govuk-!-font-weight-bold govuk-!-margin-bottom-1">Housing and homelessness</p>
+
+      <ul class="govuk-list app--query-examples">
+        <li>
+          <a href="#gsc.q=estate%20agent%20and%20landlord%20disputes">estate agent and landlord disputes</a>
+        </li>
+        <li>
+          <a href="#gsc.q=housing%20repairs">housing repairs</a>
+        </li>
+        <li>
+          <a href="#gsc.q=rent%20arrears">rent arrears</a>
+        </li>
+        <li>
+          <a href="#gsc.q=eviction">eviction</a>
+        </li>
+        <li>
+          <a href="#gsc.q=being%20made%20homeless">being made homeless</a>
+        </li>
+        <li>
+          <a href="#gsc.q=housing%20ombudsman">housing ombudsman</a>
+        </li>
+      </ul>
+    </div>
   </div>
 </div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1,3 +1,23 @@
 en:
   service:
     name: Search information about legal problems
+
+  home:
+    index:
+      lead: Enter the word or phrase that best describes your problem. You can also click on a common search term below.
+      intro: |
+        Your search results will only be from the government and organisations that have been carefully chosen to give you
+        the most relevant information, for example, Citizens Advice, Shelter and the Money Advice Service. All results are advert-free.
+
+      no_javascript:
+        warning: |
+          JavaScript is either disabled or not supported by your browser. To use this service, enable JavaScript by changing
+          your browser settings and reloading this page.
+        other_links_html: |
+          <p class="govuk-body">You can visit the following organisations as an alternative:</p>
+          <ul class="govuk-list govuk-list--bullet">
+            <li><a href="https://www.citizensadvice.org.uk" rel="external">Citizen’s Advice</a></li>
+            <li><a href="https://www.advicenow.org.uk" rel="external">AdviceNow</a></li>
+          </ul>
+
+      quick_search_heading: Common search terms


### PR DESCRIPTION
This includes all the custom styling needed, although we are aware of a few issues that will try to solve in a future separate PR.

Also, for now, the common search terms are not localised because that will also be done in a separate PR that will extract the terms to some kind of configuration file so it is not so coupled with the html markup and is easier to maintain.