### PR TITLE
Use the proper ENV variables in each workflow

### DIFF
--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -16,7 +16,7 @@ jobs:
     if: ${{ github.event.workflow_run.conclusion == 'success' }}
 
     env:
-      KUBE_NAMESPACE: elsa-relevant-search-production
+      KUBE_NAMESPACE: ${{ secrets.KUBE_PROD_NAMESPACE }}
 
     steps:
       - name: Pull from ECR
@@ -42,9 +42,9 @@ jobs:
 
       - name: Authenticate to the cluster
         env:
-          KUBE_CERT: ${{ secrets.KUBE_CERT }}
-          KUBE_TOKEN: ${{ secrets.KUBE_TOKEN }}
-          KUBE_CLUSTER: ${{ secrets.KUBE_CLUSTER }}
+          KUBE_CERT: ${{ secrets.KUBE_PROD_CERT }}
+          KUBE_TOKEN: ${{ secrets.KUBE_PROD_TOKEN }}
+          KUBE_CLUSTER: ${{ secrets.KUBE_PROD_CLUSTER }}
         run: |
           echo "${KUBE_CERT}" > ca.crt
           kubectl config set-cluster ${KUBE_CLUSTER} --certificate-authority=./ca.crt --server=https://api.${KUBE_CLUSTER}

--- a/.github/workflows/test-build-deploy.yml
+++ b/.github/workflows/test-build-deploy.yml
@@ -104,7 +104,7 @@ jobs:
     needs: build
 
     env:
-      KUBE_NAMESPACE: elsa-relevant-search-staging
+      KUBE_NAMESPACE: ${{ secrets.KUBE_NAMESPACE }}
 
     steps:
       - name: Authenticate to the cluster


### PR DESCRIPTION
The service-account in each of the namespaces has created the different ENV secrets, so we must ensure we are using the adequate ones.