### PR TITLE
Reduce screen content jumping around

### DIFF
--- a/app/views/home/index.html.erb
+++ b/app/views/home/index.html.erb
@@ -22,7 +22,7 @@
       <%=t '.no_javascript.other_links_html' %>
     </noscript>
 
-    <script async src="https://cse.google.com/cse.js?cx=35494a494c787b70b"></script>
+    <script src="https://cse.google.com/cse.js?cx=35494a494c787b70b"></script>
     <div class="gcse-search" data-personalizedAds="false"></div>
 
     <div class="app--js-enabled-show">


### PR DESCRIPTION
When loading or reloading the page, the search would take a few milliseconds to appear while the rest of the screen had been already rendered, so when it appears it jumps the content (common search terms block) down and is briefly noticeable.

Making the screen synchronous reduce/remove the jumping.