### PR TITLE
Add basic google analytics

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -23,6 +23,10 @@ module ApplicationHelper
     }.merge(attributes)
   end
 
+  def analytics_tracking_id
+    ENV['GA_TRACKING_ID']
+  end
+
   # Use this to feature-flag code that should only run/show on test environments
   def dev_tools_enabled?
     Rails.env.development? || ENV.key?('DEV_TOOLS_ENABLED')

--- a/app/views/layouts/_analytics.html.erb
+++ b/app/views/layouts/_analytics.html.erb
@@ -1,0 +1,7 @@
+<script async src="https://www.googletagmanager.com/gtag/js?id=<%= analytics_tracking_id %>"></script>
+<script>
+  window.dataLayer = window.dataLayer || [];
+  function gtag(){dataLayer.push(arguments);}
+  gtag('js', new Date());
+  gtag('config', '<%= analytics_tracking_id %>', { 'anonymize_ip': true });
+</script>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -3,6 +3,7 @@
 <% content_for(:head) do %>
   <%= csrf_meta_tags %>
   <%= csp_meta_tag %>
+  <%= render partial: 'layouts/analytics' if analytics_tracking_id.present? %>
 <% end %>
 
 <% content_for(:service_name) do %>

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -47,6 +47,13 @@ RSpec.describe ApplicationHelper, type: :helper do
     end
   end
 
+  describe '#analytics_tracking_id' do
+    it 'retrieves the environment variable' do
+      expect(ENV).to receive(:[]).with('GA_TRACKING_ID')
+      helper.analytics_tracking_id
+    end
+  end
+
   describe 'dev_tools_enabled?' do
     before do
       allow(Rails).to receive_message_chain(:env, :development?).and_return(development_env)


### PR DESCRIPTION
This is the basic setup to track visits, drop outs, etc.
More complex analytics will come as a separate PR.

The ENV variable will be added in the deploy repo `config_map.yml` in another PR.