### PR TITLE
Track common terms, and search events

### DIFF
--- a/app/assets/javascript/cse.js
+++ b/app/assets/javascript/cse.js
@@ -1,12 +1,19 @@
-window.addEventListener("DOMNodeInserted", function() {
-  // Getting rid of the pesky hardcoded inline styles pulled from google,
-  // so we can override them to give the controls a more govuk appearance.
-  document.querySelectorAll('input.gsc-input').forEach(function(e) {
-    e.removeAttribute('style')
-  });
+function fixStyling() {
+  // We use a timer to avoid function from firing multiple times
+  let stylingTimer;
 
-  // Apply the `govuk-link` class to all links in the search results
-  document.querySelectorAll('.gsc-control-cse a, .gsc-control-cse [role="link"]').forEach(function(e) {
-    e.classList.add('govuk-link')
+  $('#google-custom-search').on('DOMNodeInserted', function() {
+    clearTimeout(stylingTimer);
+
+    stylingTimer = setTimeout(function () {
+      // Getting rid of the pesky hardcoded inline styles pulled from google,
+      // so we can override them to give the controls a more govuk appearance
+      $('input.gsc-input').removeAttr('style');
+
+      // Apply the `govuk-link` class to all links in the search results
+      $('.gsc-control-cse a, .gsc-control-cse [role="link"]').addClass('govuk-link');
+    }, 5);
   });
-});
+}
+
+$(document).on('turbolinks:load', fixStyling);

--- a/app/assets/javascript/ga-events.js
+++ b/app/assets/javascript/ga-events.js
@@ -1,0 +1,81 @@
+gaEvents = {
+  linkClass: '.ga-pageLink',
+  searchTimer: null,
+
+  init: function () {
+    let self = this;
+
+    // don't bind anything if the GA object isn't defined
+    if (typeof window.gtag !== 'undefined') {
+      self.trackSearchEvents();
+
+      if ($(self.linkClass).length) {
+        self.trackLinks();
+      }
+      if ($("a[rel^=external]").length) {
+        self.trackExternalLinks();
+      }
+    }
+  },
+
+  trackSearchEvents: function() {
+    clearTimeout(self.searchTimer);
+
+    // The search box can take a while to load so we delay this a bit
+    // Also there are two ways of triggering the search: pressing enter in
+    // the search input, or clicking the search button (either with mouse or
+    // with the keyboard, with enter or space bar).
+    //
+    self.searchTimer = setTimeout(function() {
+      $('input.gsc-input').on('keyup', function(e) {
+        if (e.key === 'Enter' || e.keyCode === 13) {
+          gtag('event', 'search');
+        }
+      });
+
+      $('button.gsc-search-button').click(function() {
+        gtag('event', 'search');
+      });
+    }, 500);
+  },
+
+  trackLinks: function () {
+    let self = this,
+        $links = $(self.linkClass);
+
+    $links.on('click', function(e) {
+      let $el = $(this),
+          url = this.href;
+
+      e.preventDefault();
+
+      gtag('event', 'click', {
+        'event_category': $el.data('ga-category'),
+        'event_label': $el.data('ga-label'),
+        'event_callback': function(){ document.location = url }
+      });
+    });
+  },
+
+  // This function will not send to GA the query string, as frequently
+  // this may contain personal identification or secure tokens.
+  trackExternalLinks: function() {
+    $("a[rel^=external]").on('click', function(e) {
+      let $el = this,
+          url = $el.href,
+          event_url = url.replace($el.search, '');
+
+      e.preventDefault();
+
+      gtag('event', 'click', {
+        'event_category': 'outbound',
+        'event_label': event_url,
+        'event_callback': function(){ document.location = url }
+      });
+    });
+  }
+};
+
+$(document).on("turbolinks:load", function() {
+  gaEvents.init();
+});

--- a/app/assets/packs/application.js
+++ b/app/assets/packs/application.js
@@ -21,3 +21,4 @@ import { initAll } from 'govuk-frontend'
 initAll()
 
 import "../javascript/cse";
+import "../javascript/ga-events";

--- a/app/views/home/index.html.erb
+++ b/app/views/home/index.html.erb
@@ -22,8 +22,10 @@
       <%=t '.no_javascript.other_links_html' %>
     </noscript>
 
-    <script src="https://cse.google.com/cse.js?cx=35494a494c787b70b"></script>
-    <div class="gcse-search" data-personalizedAds="false"></div>
+    <div id="google-custom-search">
+      <script src="https://cse.google.com/cse.js?cx=35494a494c787b70b"></script>
+      <div class="gcse-search" data-personalizedAds="false"></div>
+    </div>
 
     <div class="app--js-enabled-show">
       <h2 class="govuk-heading-m govuk-!-margin-top-5">

--- a/app/views/layouts/_analytics.html.erb
+++ b/app/views/layouts/_analytics.html.erb
@@ -3,5 +3,5 @@
   window.dataLayer = window.dataLayer || [];
   function gtag(){dataLayer.push(arguments);}
   gtag('js', new Date());
-  gtag('config', '<%= analytics_tracking_id %>', { 'anonymize_ip': true });
+  gtag('config', '<%= analytics_tracking_id %>', { 'anonymize_ip': true, 'allow_google_signals': false });
 </script>

--- a/app/views/shared/_quick_search_group.html.erb
+++ b/app/views/shared/_quick_search_group.html.erb
@@ -5,7 +5,7 @@
 <ul class="govuk-list app--query-examples">
   <% quick_search_group.terms.each do |term| %>
     <li>
-      <a href="#gsc.q=<%= ERB::Util.url_encode(term) %>"><%= term %></a>
+      <%= link_to term, root_path(anchor: "gsc.q=#{term}"), class: 'ga-pageLink', data: { ga_category: 'common terms', ga_label: term } %>
     </li>
   <% end %>
 </ul>

--- a/config/webpack/environment.js
+++ b/config/webpack/environment.js
@@ -1,3 +1,12 @@
 const { environment } = require('@rails/webpacker')
+const webpack = require("webpack");
+
+environment.plugins.append("Provide",
+  new webpack.ProvidePlugin({
+    $: 'jquery',
+    jQuery: 'jquery',
+    'window.jQuery': 'jquery'
+  })
+);
 
 module.exports = environment

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "dependencies": {
     "@rails/ujs": "^6.0.0",
     "@rails/webpacker": "5.4.3",
+    "jquery": "^3.6.0",
     "turbolinks": "^5.2.0",
     "webpack": "^4.46.0",
     "webpack-cli": "^3.3.12",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3785,6 +3785,11 @@ jest-worker@^26.5.0:
     merge-stream "^2.0.0"
     supports-color "^7.0.0"
 
+jquery@^3.6.0:
+  version "3.6.0"
+  resolved "https://registry.yarnpkg.com/jquery/-/jquery-3.6.0.tgz#c72a09f15c1bdce142f49dbf1170bdf8adac2470"
+  integrity sha512-JVzAR/AjBvVt2BmYhxRCSYysDsPcssdmTFnzyLEts9qNwmjmu4JTAMYubEfwVOSwpQ1I1sKKFcxhZCI2buerfw==
+
 js-tokens@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-4.0.0.tgz#19203fb59991df98e3a287050d4647cdeaf32499"


### PR DESCRIPTION
This will track clicks on the common search terms, as well as search events, but not what the user is searching for, just an event to indicate it triggered a search.

Also included jQuery to be easier to reuse some of the code we already had, although it is quite different now.