### PR TITLE
Some accessibility improvements

### DIFF
--- a/app/assets/javascript/cse.js
+++ b/app/assets/javascript/cse.js
@@ -10,6 +10,11 @@ function fixStyling() {
       // so we can override them to give the controls a more govuk appearance
       $('input.gsc-input').removeAttr('style');
 
+      // Add input label for screen readers
+      if ($('label[for="gsc-i-id1"]').length === 0) {
+        $('<label class="govuk-label govuk-visually-hidden" for="gsc-i-id1">Enter your search terms</label>').insertBefore('input.gsc-input');
+      }
+
       // Apply the `govuk-link` class to all links in the search results
       $('.gsc-control-cse a, .gsc-control-cse [role="link"]').addClass('govuk-link');
     }, 5);

--- a/app/assets/stylesheets/local/cse.scss
+++ b/app/assets/stylesheets/local/cse.scss
@@ -26,6 +26,12 @@
   visibility: hidden;
 }
 
+a.gsst_a {
+  span.gscb_a {
+    font-weight: bold !important;
+  }
+}
+
 div.gsc-input-box {
   border: none;
 

--- a/app/views/home/index.html.erb
+++ b/app/views/home/index.html.erb
@@ -22,7 +22,7 @@
       <%=t '.no_javascript.other_links_html' %>
     </noscript>
 
-    <div id="google-custom-search">
+    <div id="google-custom-search" aria-live="assertive">
       <script src="https://cse.google.com/cse.js?cx=35494a494c787b70b"></script>
       <div class="gcse-search" data-personalizedAds="false"></div>
     </div>

--- a/app/views/shared/_quick_search_group.html.erb
+++ b/app/views/shared/_quick_search_group.html.erb
@@ -1,6 +1,6 @@
-<p class="govuk-body govuk-!-font-weight-bold govuk-!-margin-bottom-1">
+<h3 class="govuk-heading-s govuk-!-margin-bottom-1">
   <%= quick_search_group.category %>
-</p>
+</h3>
 
 <ul class="govuk-list app--query-examples">
   <% quick_search_group.terms.each do |term| %>


### PR DESCRIPTION
Some problems were found with the accessibility. Here is a bunch of fixes or improvements, more might follow as separate PRs.

- Add label to search input to describe function for screen readers
- Add `aria-live` for screen readers to announce results
- Use `h3` tag for common search terms category names
- Improved the contrast of the `x` button to clear the input text.