### PR TITLE
Add some more contrast to an element

### DIFF
--- a/app/assets/stylesheets/local/cse.scss
+++ b/app/assets/stylesheets/local/cse.scss
@@ -28,6 +28,7 @@
 
 a.gsst_a {
   span.gscb_a {
+    filter: brightness(0.85);
     font-weight: bold !important;
   }
 }


### PR DESCRIPTION
Ticket: https://trello.com/c/p7MxsLs7

As raised in the accessibility check.

This reduces the brightness, making the element slightly darker so the contrast is better and is not raised as an accessibility failure.