### PR TITLE
Mitigates text input jumping on page load

### DIFF
--- a/app/assets/stylesheets/local/custom.scss
+++ b/app/assets/stylesheets/local/custom.scss
@@ -20,3 +20,9 @@ ul.app--query-examples {
     margin-right: govuk-spacing(2);
   }
 }
+
+// This mitigates the input text jumping around on page loads while
+// the javascript takes over and style it properly.
+#google-custom-search {
+  min-height: 85px;
+}


### PR DESCRIPTION
There is some javascript magic that we use to re-style the text input and button on page load. However there is a small delay until this happen and the element made a brief jump on the page.

Setting a min-height ensures the element stays in its place and the common terms (below) will not take its space.